### PR TITLE
correctly truncate messages in syslog sink

### DIFF
--- a/lib/steno/sink/syslog.rb
+++ b/lib/steno/sink/syslog.rb
@@ -9,6 +9,7 @@ unless Steno::Sink::WINDOWS
     include Singleton
 
     MAX_MESSAGE_SIZE = 1024 * 3
+    TRUNCATE_POSTFIX = "..."
 
     LOG_LEVEL_MAP = {
         :fatal  => Syslog::LOG_CRIT,
@@ -48,8 +49,8 @@ unless Steno::Sink::WINDOWS
     def truncate_record(record)
       return record if record.message.size <= MAX_MESSAGE_SIZE
 
-      truncated = record.message.slice(0..(MAX_MESSAGE_SIZE - 1))
-      truncated << "..."
+      truncated = record.message.slice(0...(MAX_MESSAGE_SIZE - TRUNCATE_POSTFIX.size))
+      truncated << TRUNCATE_POSTFIX
       Steno::Record.new(record.source, record.log_level,
                         truncated,
                         [record.file, record.lineno, record.method],

--- a/spec/unit/sink/syslog_spec.rb
+++ b/spec/unit/sink/syslog_spec.rb
@@ -47,12 +47,13 @@ unless Steno::Sink::WINDOWS
         sink.open(identity)
 
         truncated = record_with_big_message.message.
-            slice(0..(Steno::Sink::Syslog::MAX_MESSAGE_SIZE) - 1)
-        truncated << "..."
+            slice(0..(Steno::Sink::Syslog::MAX_MESSAGE_SIZE) - 4)
+        truncated << Steno::Sink::Syslog::TRUNCATE_POSTFIX
         codec = double("codec")
         codec.should_receive(:encode_record) do |*args|
           args.size.should == 1
           args[0].message.should == truncated
+          args[0].message.size.should <= Steno::Sink::Syslog::MAX_MESSAGE_SIZE
 
           next args[0].message
         end


### PR DESCRIPTION
Instead of removing one character and adding three (...), remove the correct amount

Signed-off-by: Nick Wade nwade@pivotallabs.com
