### PR TITLE
Add human-readable date output option

### DIFF
--- a/lib/steno/codec/json.rb
+++ b/lib/steno/codec/json.rb
@@ -8,6 +8,11 @@ module Steno
 end
 
 class Steno::Codec::Json < Steno::Codec::Base
+
+  def initialize(opts = {})
+    @iso8601_timestamps = opts[:iso8601_timestamps] || false
+  end
+
   def encode_record(record)
     msg =
       if record.message.valid_encoding?
@@ -31,6 +36,14 @@ class Steno::Codec::Json < Steno::Codec::Base
       "method"     => record.method,
     }
 
-    Yajl::Encoder.encode(h) + "\n"
+    if iso8601_timestamps?
+      h["timestamp"] = Time.at(record.timestamp).utc.iso8601(6)
+    end
+
+     Yajl::Encoder.encode(h) + "\n"
+  end
+
+  def iso8601_timestamps?
+    @iso8601_timestamps
   end
 end

--- a/lib/steno/config.rb
+++ b/lib/steno/config.rb
@@ -41,6 +41,10 @@ class Steno::Config
         :default_log_level => level.nil? ? :info : level.to_sym
       }
 
+      if hash[:iso8601_timestamps]
+        opts[:codec] = Steno::Codec::Json.new(:iso8601_timestamps => true)
+      end
+
       if hash[:file]
         max_retries = hash[:max_retries]
         opts[:sinks] << Steno::Sink::IO.for_file(hash[:file], :max_retries => max_retries)

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -131,6 +131,14 @@ describe Steno::Config do
       config.context.class.should == Steno::Context::Null
 
       config.codec.class.should == Steno::Codec::Json
+      config.codec.iso8601_timestamps?.should == false
+    end
+
+    it "should configure json codec with readable dates if iso8601_timestamps is true" do
+      write_config(@config_path, {"iso8601_timestamps" => "true"})
+      config = Steno::Config.from_file(@config_path)
+      config.codec.class.should == Steno::Codec::Json
+      config.codec.iso8601_timestamps?.should == true
     end
 
     it "should set the default_log_level if a key with the same name is supplied" do

--- a/spec/unit/json_codec_spec.rb
+++ b/spec/unit/json_codec_spec.rb
@@ -36,6 +36,26 @@ describe Steno::Codec::Json do
       rec = make_record(:message => msg)
       codec.encode_record(rec).should match(/HI\\\\xe2\\\\x80\\\\xa6/)
     end
+
+    it "shouldn't use readable dates by default" do
+      codec.iso8601_timestamps?.should == false
+    end
+
+    context "when iso8601_timestamps is set" do
+      let(:codec) { Steno::Codec::Json.new( :iso8601_timestamps => true ) }
+
+      it "should encode timestamps as UTC-formatted strings" do
+        allow(record).to receive(:timestamp).and_return 1396473763.811278 # 2014-04-02 22:22:43 +01:00
+        parsed = Yajl::Parser.parse(codec.encode_record(record))
+
+        parsed["timestamp"].class.should == String
+        parsed["timestamp"].should eq("2014-04-02T21:22:43.811278Z")
+      end
+
+      it "should surface the property in a getter" do
+        codec.iso8601_timestamps?.should == true
+      end
+    end
   end
 
   def make_record(opts = {})


### PR DESCRIPTION
In order to enable the changes agreed to in https://github.com/cloudfoundry/cloud_controller_ng/issues/181, adds a readable_dates option which formats dates in a way that's still machine readable, but is also human-friendly. I considered changing the default, but in case anyone is relying on the previous date format it seemed safer to expose as a config option which defaults to the old behaviour. 

I'm also open to the idea of adding a ReadableJson codec or similar rather than modifying the existing Json codec, but that seemed like more complication than this change warranted.
