### PR TITLE
Fix deprecation warning

### DIFF
--- a/spec/unit/sink/io_spec.rb
+++ b/spec/unit/sink/io_spec.rb
@@ -96,7 +96,7 @@ describe Steno::Sink::IO do
       expect do
         Steno::Sink::IO.new(io, :codec => codec, :max_retries => 1).
           add_record(record)
-      end.to_not raise_error(IOError)
+      end.to_not raise_error
     end
   end
 


### PR DESCRIPTION
see https://github.com/rspec/rspec-expectations/issues/231. Really not a big deal, but it was bugging me. 
